### PR TITLE
fix(CI): remove duplicate `actions` field

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -12,7 +12,6 @@ jobs:
     permissions:
       contents: read
       actions: write
-      actions: write
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Removed duplicate 'actions: write' permission.